### PR TITLE
Fix copy.Copy in windows by removing \n\r from file paths

### DIFF
--- a/cmd/get-repo-images/find-images.go
+++ b/cmd/get-repo-images/find-images.go
@@ -38,6 +38,8 @@ func findImages(settings RepoSettings, siteFlag bool) ([]Image, error) {
 				}
 
 				var imgPath = strings.Replace(fpath, repoDir+"/", "", 1)
+				imgPath = strings.TrimSuffix(imgPath, "\n")
+				imgPath = strings.TrimSuffix(imgPath, "\r")
 
 				if minSize < info.Size() {
 					images = append(images, Image{


### PR DESCRIPTION
Fix https://github.com/Shopify/get-repo-images/issues/18

Following guidance from [Go ReadString issues: The filename, directory name, or volume label syntax is incorrect](https://stackoverflow.com/questions/50711414/go-readstring-issues-the-filename-directory-name-or-volume-label-syntax-is-in) it seems to be common that file paths can contain new lines on windows.

> On Windows, the line is terminated with "\r\n".