### PR TITLE
Replace shopify/android with shopify/mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npx @shopify/get-repo-images -config
 {
   "repos": [
     {
-      "repo": "shopify/android",
+      "repo": "shopify/mobile",
       "minSize": 1000,
       "extensions": ["webp"],
       "usageMatchers": ["drawable"],


### PR DESCRIPTION
The iOS and Android repos were merged into Shopify/mobile. The Android repo is deprecated and this change updates the repo reference.