### PR TITLE
Include repo in key for ImageCard list to prevent key conflicts

### DIFF
--- a/site-template/src/pages/index.jsx
+++ b/site-template/src/pages/index.jsx
@@ -126,7 +126,7 @@ function HomePage() {
       <main>
         <ul className="cards">
           {images.map(image =>
-            <li key={image.path}>
+            <li key={image.repo + image.path}>
               <ImageCard image={image} referenceOnClick={setUsageModal} />
             </li>
           )}


### PR DESCRIPTION
I'm not sure if you're accepting PRs on this project, but I figured I would submit a fix alongside the bug report itself.

# What are you trying to accomplish?

Currently, the Next.js app uses the `path` property to render the list of images:

```js
<ul className="cards">
  {images.map(image =>
    <li key={image.path}>
      <ImageCard image={image} referenceOnClick={setUsageModal} />
    </li>
  )}
</ul>
```

However, the image path is not guaranteed to be unique across repositories. Testing the Next.js application out on a couple of repositories, I quickly ran into problems with images not being removed even after updating filters because of duplicate keys:

<img width="429" alt="Screen Shot 2021-07-08 at 2 54 16 PM" src="https://user-images.githubusercontent.com/16616777/124975776-62f66680-dffc-11eb-9104-363db91b3429.png">

# What approach did you choose and why?

Prefix the key with the image repository so there's at least a stronger guarantee of the key being unique. I think this is the most straightforward solution.